### PR TITLE
Fix projectile despawn bug

### DIFF
--- a/lib/src/damage/mod.rs
+++ b/lib/src/damage/mod.rs
@@ -158,7 +158,7 @@ fn handle_hit(
 
         // Despawns
         defender.spawner.despawn_on_hit(commands);
-        attacker.spawner.despawn(commands, vec![effect.id]);
+        attacker.spawner.despawn_for_move(commands, effect.id);
     }
 }
 


### PR DESCRIPTION
Add item_id property to OnHitEffect that will be used to despawn projectiles.
Change despawning to use unique Entity id instead of moveId.